### PR TITLE
Ability to skip the photo if it's not required

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -69,6 +69,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     public let manualSelect: Bool
     public let scanInterval: Double
     public let showViewfinder: Bool
+    public let requirePhotoOutput: Bool
     public var simulatedData = ""
     public var shouldVibrateOnSuccess: Bool
     public var isTorchOn: Bool
@@ -82,6 +83,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         manualSelect: Bool = false,
         scanInterval: Double = 2.0,
         showViewfinder: Bool = false,
+        requirePhotoOutput: Bool = true,
         simulatedData: String = "",
         shouldVibrateOnSuccess: Bool = true,
         isTorchOn: Bool = false,
@@ -93,6 +95,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         self.scanMode = scanMode
         self.manualSelect = manualSelect
         self.showViewfinder = showViewfinder
+        self.requirePhotoOutput = requirePhotoOutput
         self.scanInterval = scanInterval
         self.simulatedData = simulatedData
         self.shouldVibrateOnSuccess = shouldVibrateOnSuccess

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -15,7 +15,7 @@ extension CodeScannerView {
     public class ScannerViewController: UIViewController, UINavigationControllerDelegate {
         private let photoOutput = AVCapturePhotoOutput()
         private var isCapturing = false
-        private var handler: ((UIImage) -> Void)?
+        private var handler: ((UIImage?) -> Void)?
         var parentView: CodeScannerView!
         var codesFound = Set<String>()
         var didFinishScanning = false
@@ -437,12 +437,7 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
         if let metadataObject = metadataObjects.first {
             guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
             guard let stringValue = readableObject.stringValue else { return }
-
-            guard didFinishScanning == false else { return }
-
-            let photoSettings = AVCapturePhotoSettings()
-            guard !isCapturing else { return }
-            isCapturing = true
+            guard didFinishScanning == false && isCapturing == false else { return }
 
             handler = { [self] image in
                 let result = ScanResult(string: stringValue, type: readableObject.type, image: image, corners: readableObject.corners)
@@ -471,7 +466,13 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
                     }
                 }
             }
-            photoOutput.capturePhoto(with: photoSettings, delegate: self)
+
+            if parentView.requirePhotoOutput {
+                isCapturing = true
+                photoOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
+            } else {
+                handler?(nil)
+            }
         }
     }
 }


### PR DESCRIPTION
Make taking photo optional for performance reasons so the apps that just want the codes without the actual images can benefit from quick scans