### PR TITLE
Ability to continuously scan by ignoring specific codes

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -53,8 +53,20 @@ public enum ScanMode {
     /// Keep scanning all codes until dismissed.
     case continuous
 
+    /// Keep scanning all codes - except the ones from the ignored list - until dismissed.
+    case continuousExcept(ignoredList: Set<String>)
+
     /// Scan only when capture button is tapped.
     case manual
+
+    var isManual: Bool {
+        switch self {
+        case .manual:
+            return true
+        case .once, .oncePerCode, .continuous, .continuousExcept:
+            return false
+        }
+    }
 }
 
 /// A SwiftUI view that is able to scan barcodes, QR codes, and more, and send back what was found.
@@ -114,7 +126,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         uiViewController.updateViewController(
             isTorchOn: isTorchOn,
             isGalleryPresented: isGalleryPresented.wrappedValue,
-            isManualCapture: scanMode == .manual,
+            isManualCapture: scanMode.isManual,
             isManualSelect: manualSelect
         )
     }

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -400,7 +400,7 @@ extension CodeScannerView {
         }
         
         public func readyManualCapture() {
-            guard parentView.scanMode == .manual else { return }
+            guard parentView.scanMode.isManual else { return }
             self.reset()
             lastTime = Date()
         }
@@ -463,6 +463,11 @@ extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsD
 
                 case .continuous:
                     if isPastScanInterval() {
+                        found(result)
+                    }
+
+                case .continuousExcept(let ignoredList):
+                    if isPastScanInterval() && !ignoredList.contains(stringValue) {
                         found(result)
                     }
                 }


### PR DESCRIPTION
Problem statement:
When scanning the same barcode again (either right away or after scanning another product) - could be done by `continuous` option, but the handler would be called each time which could be undesirable (for example, presenting a sheet when a code is detected). Using `oncePerCode` kind of does the trick, but scanning the same code again doesn't work as the name suggests.

Solution:
Ability to recognize any barcode except the specific "ignored" list which could let us put the current barcode into the ignored list and once another code is detected we update the list (like a "dynamic oncePerCode")