### PR TITLE
Ability Pause scanning temporarily

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -85,6 +85,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     public var simulatedData = ""
     public var shouldVibrateOnSuccess: Bool
     public var isTorchOn: Bool
+    public var isPaused: Bool
     public var isGalleryPresented: Binding<Bool>
     public var videoCaptureDevice: AVCaptureDevice?
     public var completion: (Result<ScanResult, ScanError>) -> Void
@@ -99,6 +100,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         simulatedData: String = "",
         shouldVibrateOnSuccess: Bool = true,
         isTorchOn: Bool = false,
+        isPaused: Bool = false,
         isGalleryPresented: Binding<Bool> = .constant(false),
         videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.bestForVideo,
         completion: @escaping (Result<ScanResult, ScanError>) -> Void
@@ -112,6 +114,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         self.simulatedData = simulatedData
         self.shouldVibrateOnSuccess = shouldVibrateOnSuccess
         self.isTorchOn = isTorchOn
+        self.isPaused = isPaused
         self.isGalleryPresented = isGalleryPresented
         self.videoCaptureDevice = videoCaptureDevice
         self.completion = completion

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 @available(macCatalyst 14.0, *)
 extension CodeScannerView {
     
-    public class ScannerViewController: UIViewController, UINavigationControllerDelegate {
+    public final class ScannerViewController: UIViewController, UINavigationControllerDelegate {
         private let photoOutput = AVCapturePhotoOutput()
         private var isCapturing = false
         private var handler: ((UIImage?) -> Void)?
@@ -174,7 +174,7 @@ extension CodeScannerView {
         }
       
         private func setupSession() {
-            guard let captureSession = captureSession else {
+            guard let captureSession else {
                 return
             }
             

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -436,9 +436,12 @@ extension CodeScannerView {
 extension CodeScannerView.ScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
     public func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         if let metadataObject = metadataObjects.first {
-            guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
-            guard let stringValue = readableObject.stringValue else { return }
-            guard !didFinishScanning && !isCapturing else { return }
+            guard !parentView.isPaused && !didFinishScanning && !isCapturing,
+                  let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
+                  let stringValue = readableObject.stringValue
+            else {
+                return
+            }
 
             handler = { [self] image in
                 let result = ScanResult(string: stringValue, type: readableObject.type, image: image, corners: readableObject.corners)


### PR DESCRIPTION
If a user is taking an action with the result of the scanned barcode and in the meantime the app recognizes another barcode then the user's progress could be lost, hence the need for the ability to pause.

Also minor improvements:
 - `final class`
 - `guard let captureSession = captureSession else` -> `guard let captureSession else`